### PR TITLE
DO NOT MERGE Fix #149 Heroku doesn't pick up changed environment variables

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node server.js
+web: yarn start

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "clean": "rimraf bundle.js bundle.js.map",
     "build": "webpack --config=webpack.config.js -p",
-    "postinstall": "$npm_execpath run clean && $npm_execpath run build",
-    "start": "node server.js",
+    "start": "([ -f .env ] || $npm_execpath run build) && node server.js",
     "dev": "webpack-dev-server --inline --hot",
     "lint": "$npm_execpath run lint:js && $npm_execpath run lint:markdown",
     "lint:js": "eslint --cache --ext .js,.jsx src *.js",

--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ app.use(bodyParser.json({ type: 'application/*+json' }));
 app.use(express.static(__dirname));
 
 // Check if we're running on a local dev machine
+// TODO: Remove use of .env. Change instructions to direct users to direnv
 if (fs.existsSync('./.env')) {
   // Load environment variables from .env
   require('dotenv').config();


### PR DESCRIPTION
Move the webpack build step from postinstall to start.

This makes bringing up a dyno slower (although the build is faster, so it should be the same total time for a new deployment), but the app picks up changes to environment variables without requiring a re-deploy.

This also brings another couple of benefits:
* `yarn start` runs the latest sources. This is typically what I want; the fact that it doesn't has got me a few times. (`yarn run` is available to just run the production server, without building the client.)
* `yarn install` no longer runs webpack. This was undesireable behavior (although fixing just this could have been accomplished by moving the build from `postinstall` to `heroku-postbuild`).

## Description
Describe your changes here.
## Required
Changes must conform to these requirements:
* [ ] `yarn test` passes.  All new and existing tests pass.
* [ ] `yarn lint` passes. All new code follows the code style of this project.

## Aspirational
We don't yet require these, but they are nice to have:
* [ ] New code is covered by new or existing tests.
* [ ] Changed code is covered by new or existing tests.
