### PR TITLE
Factor out client API; show some messages in the page

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -773,3 +773,21 @@ textarea.markdown-editor {
         transform: rotate(360deg);
     }
 }
+
+.messages {
+    z-index: 1000;
+    width: 100%;
+    background: yellow;
+    padding: 5px 15px;
+    position: absolute;
+    transition: transform 0.5s;
+    transform: scaleY(1);
+}
+
+.messages.count-0 {
+    transform: scaleY(0);
+}
+
+.messages.count-0 .closebox {
+    display: none;
+}

--- a/src/__test__/add-edit-page.test.jsx
+++ b/src/__test__/add-edit-page.test.jsx
@@ -6,10 +6,10 @@ import AddEditEventPage from '../pages/add-edit/add-edit-page';
 
 describe('AddEditEventPage', () => {
   const userAccount = {
-    scope: new Map(),
+    scope: new Set(),
   };
   const adminAccount = {
-    scope: new Map(),
+    scope: new Set(),
   };
   const event = {
     title: 'An event title',

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -12,7 +12,12 @@ import LabelsContainer from './containers/labels-container';
 import SidebarContainer from './containers/sidebar-container';
 import SubscriptionContainer from './containers/subscription-container';
 import { withAccountInfo } from './containers/with-server-data';
-import { fetchLabels, fetchAccessInfo, toggleSidebarCollapsed } from './data/actions';
+import {
+  clearMessages,
+  fetchAccessInfo,
+  fetchLabels,
+  toggleSidebarCollapsed,
+} from './data/actions';
 import { initializeAccessToken } from './data/auth';
 import setupStore from './data/setup-store';
 
@@ -27,8 +32,14 @@ initializeAccessToken();
 store.dispatch(fetchAccessInfo());
 store.dispatch(fetchLabels());
 
-const App = () => (
+const App = ({ messages, onMessageClose }) => (
   <div className="app-container">
+    <div className={`messages count-${messages.length}`}>
+      <span className="closebox big ion-ios-close" onClick={onMessageClose}>
+        &nbsp;
+      </span>
+      {messages.map(({ id, message }) => <p key={id}>{message}</p>)}
+    </div>
     <SidebarContainer />
     <div className="scene-container">
       <div className="scene-overlay" onClick={() => store.dispatch(toggleSidebarCollapsed())} />
@@ -50,9 +61,20 @@ const App = () => (
 // Guard the entire app, in order to get a single loading indicator instead of
 // one for the sidebar and another for the main calendar view
 const mapStateToProps = state => ({
+  messages: state.messages,
   user: state.user,
 });
-const AppContainer = connect(mapStateToProps)(withAccountInfo(App));
+
+const mapDispatchToProps = dispatch => ({
+  onMessageClose: (mode) => {
+    dispatch(clearMessages(mode));
+  },
+});
+
+const AppContainer = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(withAccountInfo(App));
 
 ReactDOM.render(
   <Provider store={store}>

--- a/src/containers/import-container.js
+++ b/src/containers/import-container.js
@@ -35,7 +35,7 @@ const mapDispatchToProps = (dispatch, getState) => ({
   setPageTitlePrefix: (title) => {
     dispatch(setPageTitlePrefix(title));
   },
-  importSuccess: (response, importData) => {
+  importSuccess: (importData) => {
     ga.event({
       category: 'ICS Feed Import',
       variable: 'success',
@@ -57,6 +57,9 @@ const mapDispatchToProps = (dispatch, getState) => ({
 });
 
 // Connect props to Redux state and actions
-const ImportContainer = connect(mapStateToProps, mapDispatchToProps)(ImportPage);
+const ImportContainer = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ImportPage);
 
 export default ImportContainer;

--- a/src/containers/subscription-container.js
+++ b/src/containers/subscription-container.js
@@ -30,7 +30,7 @@ const mapDispatchToProps = (dispatch, getState) => ({
   setPageTitlePrefix: (title) => {
     dispatch(setPageTitlePrefix(title));
   },
-  importSuccess: (response, importData) => {
+  importSuccess: (importData) => {
     ga.event({
       category: 'Subscription Preferences',
       variable: 'success',
@@ -51,6 +51,9 @@ const mapDispatchToProps = (dispatch, getState) => ({
 });
 
 // Connect props to Redux state and actions
-const SubscriptionContainer = connect(mapStateToProps, mapDispatchToProps)(SubscriptionEditorPage);
+const SubscriptionContainer = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(SubscriptionEditorPage);
 
 export default SubscriptionContainer;

--- a/src/data/client.js
+++ b/src/data/client.js
@@ -1,0 +1,8 @@
+import axios from 'axios';
+import { API_SERVER_URL } from './settings';
+
+const apiClient = axios.create({
+  baseURL: API_SERVER_URL,
+});
+
+export default apiClient;

--- a/src/data/reducers.js
+++ b/src/data/reducers.js
@@ -1,23 +1,15 @@
-// This file contains a bunch of Redux reducers
-
+// Redux reducers
 import SidebarModes from '../data/sidebar-modes';
 import { ActionTypes } from './actions';
 
 export function general(state = {}, action) {
-  const newState = Object.assign({}, state);
-
   switch (action.type) {
-    case ActionTypes.DISPLAY_MESSAGE:
-      alert(action.message);
-      return state;
-    case ActionTypes.DISPLAY_ERROR:
-      alert(action.message ? action.message : action.error);
-      console.error(action.error);
-      return state;
     case ActionTypes.SET_PAGE_TITLE_PREFIX:
       window.document.title = action.title;
-      newState.general = Object.assign({}, newState.general, { pageTitlePrefix: action.title });
-      return newState;
+      return {
+        ...state,
+        general: { ...state.general, pageTitlePrefix: action.title },
+      };
     default:
       return state;
   }
@@ -33,15 +25,29 @@ export function user(state = {}, action) {
 }
 
 export function calendar(state = {}, action) {
-  const newState = Object.assign({}, state);
-
   switch (action.type) {
     case ActionTypes.SET_FOCUSED_DATE:
-      newState.currentlyViewingDate = action.data;
-      return newState;
+      return { ...state, currentlyViewingDate: action.data };
     case ActionTypes.SET_VIEW_MODE:
-      newState.currentViewMode = action.data;
-      return newState;
+      return { ...state, currentViewMode: action.data };
+    default:
+      return state;
+  }
+}
+
+export function messages(state = [], action) {
+  switch (action.type) {
+    case ActionTypes.CLEAR_MESSAGES:
+      return [];
+    case ActionTypes.DISPLAY_MESSAGE:
+      alert(action.message);
+      return [{ id: +new Date(), type: 'message', message: action.message }, ...state];
+    case ActionTypes.DISPLAY_ERROR:
+      alert(action.message || action.error);
+      return [
+        { id: +new Date(), type: 'error', message: String(action.message || action.error) },
+        ...state,
+      ];
     default:
       return state;
   }
@@ -50,20 +56,14 @@ export function calendar(state = {}, action) {
 export function events(state = {}, action) {
   switch (action.type) {
     case ActionTypes.CLEAR_CURRENT_EVENT:
-      return Object.assign({}, state, {
-        current: null,
-      });
+      return { ...state, current: null };
     case ActionTypes.SET_CURRENT_EVENT:
-      return Object.assign({}, state, {
-        current: action.data,
-      });
+      return { ...state, current: action.data };
     case ActionTypes.SET_EVENTS:
-      // Sort the list of labels on each event so that events with the same labels
-      // always display with the same color
+      // Sort the list of labels on each event so that events with the same
+      // labels always display with the same color
       Object.values(action.data).forEach(event => event.labels.sort());
-      return Object.assign({}, state, {
-        events: action.data,
-      });
+      return { ...state, events: action.data };
     default:
       return state;
   }
@@ -72,40 +72,39 @@ export function events(state = {}, action) {
 export function sidebar(state = SidebarModes.LOADING, action) {
   switch (action.type) {
     case ActionTypes.TOGGLE_SIDEBAR_VISIBILITY:
-      return Object.assign({}, state, {
-        isCollapsed: !state.isCollapsed,
-      });
+      return { ...state, isCollapsed: !state.isCollapsed };
     case ActionTypes.SET_SIDEBAR_MODE:
-      return Object.assign({}, state, { mode: action.mode });
+      return { ...state, mode: action.mode };
     default:
       return state;
   }
 }
 
 export function labels(state = {}, action) {
-  let newState;
   switch (action.type) {
     case ActionTypes.FETCH_LABELS_IF_NEEDED:
       return state;
 
     case ActionTypes.SET_LABELS: {
-      newState = Object.assign({}, state);
       const labelList = action.data;
-      newState.labelList = labelList;
+      const defaultLabelNames = () =>
+        Object.values(labelList)
+          .filter(l => l.default)
+          .map(l => l.name);
 
-      // If the visible labels array hasn't been set yet, set it to be the default
-      if (!state.visibleLabels) {
-        const labelsArray = Object.values(labelList);
-        newState.visibleLabels =
-          labelsArray.length > 0 ? labelsArray.filter(l => l.default).map(l => l.name) : [];
-      }
-      return newState;
+      return {
+        ...state,
+        labelList,
+        // If the visible labels array hasn't been set yet, set it to be the default
+        visibleLabels: state.visibleLabels || defaultLabelNames(),
+      };
     }
 
     case ActionTypes.SET_FILTER_LABELS:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         visibleLabels: action.data,
-      });
+      };
 
     case ActionTypes.FILTER_LABEL_TOGGLED: {
       const visibleLabels = state.visibleLabels.slice();
@@ -114,7 +113,7 @@ export function labels(state = {}, action) {
       } else {
         visibleLabels.push(action.labelName);
       }
-      return Object.assign({}, state, { visibleLabels });
+      return { ...state, visibleLabels };
     }
 
     default:

--- a/src/data/setup-store.js
+++ b/src/data/setup-store.js
@@ -57,6 +57,7 @@ export default function setupStore(history) {
       labelList: null,
       visibleLabels: null,
     },
+    messages: [],
   };
 
   initialState.calendar.currentViewMode = isMobile

--- a/src/pages/import/import.jsx
+++ b/src/pages/import/import.jsx
@@ -1,11 +1,10 @@
 // This component allows the user to import a calendar from an ICS feed
 
-import axios from 'axios';
 import * as React from 'react';
 import TagPane from '../../components/label-pane';
 import MenuIconButton from '../../components/menu-icon-button';
+import apiClient from '../../data/client';
 import SidebarModes from '../../data/sidebar-modes';
-import { API_SERVER_URL } from '../../data/settings';
 
 export default class ImportPage extends React.Component {
   constructor(props) {
@@ -36,12 +35,11 @@ export default class ImportPage extends React.Component {
   };
 
   submitICS = () => {
-    axios
-      .post(`${API_SERVER_URL}/ics/`, this.state.importData)
-      .then(
-        response => this.props.importSuccess(response, this.state.importData),
-        (jqXHR, textStatus, errorThrown) => this.props.importFailed(errorThrown, jqXHR.message),
-      );
+    apiClient
+      .post('/ics/', this.state.importData)
+      .then(({ data }) => this.props.importSuccess(data))
+      .catch((jqXHR, textStatus, errorThrown) =>
+        this.props.importFailed(errorThrown, jqXHR.message));
   };
 
   render() {

--- a/src/sidebar/generate-ics-pane.jsx
+++ b/src/sidebar/generate-ics-pane.jsx
@@ -1,12 +1,12 @@
 // The component provides information to the user about ICS feed generation. It also gives
 // them a button to click to generate an ICS feed.
 
-import axios from 'axios';
 import copy from 'copy-to-clipboard';
 import React from 'react';
 import { OutboundLink } from 'react-ga';
-import docs from '../docs';
+import apiClient from '../data/client';
 import { API_SERVER_URL } from '../data/settings';
+import docs from '../docs';
 
 export default class GenerateICSPane extends React.Component {
   constructor(props) {
@@ -32,14 +32,10 @@ export default class GenerateICSPane extends React.Component {
 
     const labels = this.props.selectedLabels;
 
-    const url = `${API_SERVER_URL}/subscriptions/`;
-
-    axios.post(url, { labels }).then(
-      (response) => {
-        this.setState({ data: Object.assign({}, this.state.data, response.data) });
-      },
-      (_jqXHR, _textStatus, _errorThrown) => alert('Failed to get Feed URL'),
-    );
+    apiClient
+      .post('/subscriptions/', { labels })
+      .catch((_jqXHR, _textStatus, _errorThrown) => alert('Failed to get Feed URL'))
+      .then(({ data }) => this.setState({ data: Object.assign({}, this.state.data, data) }));
   }
 
   copyToClipboard(url) {

--- a/src/sidebar/sidebar.jsx
+++ b/src/sidebar/sidebar.jsx
@@ -105,7 +105,7 @@ const Sidebar = (props) => {
         // For viewing the calendar
         <SidebarItem key="logout" header="Sign Out">
           <a onClick={onSignOut}>Sign out</a> of {olinBuildLogo}. While signed out, you will only be
-          able to view public events when you are outside the intranet.
+          able to view public events unless you are inside the intranet.
         </SidebarItem>
       )}
     </div>


### PR DESCRIPTION
* Replace (most) use of base `axios` methods by calls on an axios instance that knows the API server's base URL
* (wip) Add a message list, as a future alternative to `alert`.